### PR TITLE
closes #28

### DIFF
--- a/hs-conllu.cabal
+++ b/hs-conllu.cabal
@@ -1,5 +1,5 @@
 name:                hs-conllu
-version:             0.1.3
+version:             0.1.4
 synopsis:            Conllu validating parser and utils.
 description:         utilities to parse, print, diff, and analyse data in CoNLL-U format.
 extra-doc-files:      README

--- a/src/Conllu/DeprelTagset.hs
+++ b/src/Conllu/DeprelTagset.hs
@@ -16,15 +16,16 @@
 module Conllu.DeprelTagset where
 
 data EP
-  = ACL
+  = REF -- ^ only allowed in DEPS
+  | ACL
   | ADVCL
   | ADVMOD
   | AMOD
   | APPOS
   | AUX
   | CASE
-  | CC
   | CCOMP
+  | CC
   | CLF
   | COMPOUND
   | CONJ
@@ -49,7 +50,6 @@ data EP
   | ORPHAN
   | PARATAXIS
   | PUNCT
-  | REF -- ^ only allowed in DEPS
   | REPARANDUM
   | ROOT
   | VOCATIVE


### PR DESCRIPTION
- change the order of the DEPREL tagset
  - REF becomes first, and is not used in parsing
  - ccomp comes before cc, so that it is parsed without errors