### PR TITLE
starting to bring to new version of ghc

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-10.3
+resolver: lts-13.12
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
I tried to bring the package to a more current ghc (8.6.4) with lts-13.12 but found a number of errors, mostly with regards to Megaparsec and error handling - which I do not understand very well. 
Could you try to fix them? Thank you!