### PR TITLE
fixed errors with new version of mergaparsec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,10 @@ matrix:
 
 
 before_install:
-- mkdir -p ~/.local/bin
+- travis_retry curl -sSL https://get.haskellstack.org/ | sh
+- stack build
+- stack upgrade
 - export PATH=$HOME/.local/bin:$PATH
-- travis_retry curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
-- stack config set system-ghc --global true
-- export PATH=/opt/ghc/$GHCVER/bin:$PATH
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,9 @@
 #
 # https://docs.haskellstack.org/en/stable/travis_ci/
 #
-# Copy these contents into the root directory of your Github project in a file
-# named .travis.yml
 
 # Use new container infrastructure to enable caching
 sudo: false
-
-# Do not choose a language; we provide our own build tools.
-language: generic
 
 # Caching so the next build will be fast too.
 cache:
@@ -21,211 +16,41 @@ cache:
   - $HOME/.cabal
   - $HOME/.stack
 
-# The different configurations we want to test. We have BUILD=cabal which uses
-# cabal-install, and BUILD=stack which uses Stack. More documentation on each
-# of those below.
+  
+# The different configurations we want to test. We have BUILD=cabal
+# which uses cabal-install, and BUILD=stack which uses Stack. More
+# documentation on each of those below.
 #
 # We set the compiler values here to tell Travis to use a different
 # cache file per set of arguments.
-#
-# If you need to have different apt packages for each combination in the
-# matrix, you can use a line such as:
-#     addons: {apt: {packages: [libfcgi-dev,libgmp-dev]}}
+
 matrix:
   include:
-  # We grab the appropriate GHC and cabal-install versions from hvr's PPA. See:
-  # https://github.com/hvr/multi-ghc-travis
-  #- env: BUILD=cabal GHCVER=7.0.4 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
-  #  compiler: ": #GHC 7.0.4"
-  #  addons: {apt: {packages: [cabal-install-1.16,ghc-7.0.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  #- env: BUILD=cabal GHCVER=7.2.2 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
-  #  compiler: ": #GHC 7.2.2"
-  #  addons: {apt: {packages: [cabal-install-1.16,ghc-7.2.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  #- env: BUILD=cabal GHCVER=7.4.2 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
-  #  compiler: ": #GHC 7.4.2"
-  #  addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  #- env: BUILD=cabal GHCVER=7.6.3 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
-  #  compiler: ": #GHC 7.6.3"
-  #  addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  #- env: BUILD=cabal GHCVER=7.8.4 CABALVER=1.18 HAPPYVER=1.19.5 ALEXVER=3.1.7
-  #  compiler: ": #GHC 7.8.4"
-  #  addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  #- env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22 HAPPYVER=1.19.5 ALEXVER=3.1.7
-  #  compiler: ": #GHC 7.10.3"
-  #  addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  - env: BUILD=cabal GHCVER=8.0.2 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 8.0.2"
-    addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  - env: BUILD=cabal GHCVER=8.2.2 CABALVER=2.0 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 8.2.2"
-    addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  - env: BUILD=cabal GHCVER=8.4.2 CABALVER=2.2 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 8.4.2"
-    addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-
-  # Build with the newest GHC and cabal-install. This is an accepted failure,
-  # see below.
-  - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC HEAD"
-    addons: {apt: {packages: [cabal-install-head,ghc-head,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-
-  # The Stack builds. We can pass in arbitrary Stack arguments via the ARGS
-  # variable, such as using --stack-yaml to point to a different file.
-  - env: BUILD=stack ARGS=""
-    compiler: ": #stack default"
-    addons: {apt: {packages: [libgmp-dev]}}
-
-  #- env: BUILD=stack ARGS="--resolver lts-2"
-  #  compiler: ": #stack 7.8.4"
-  #  addons: {apt: {packages: [libgmp-dev]}}
-
-  #- env: BUILD=stack ARGS="--resolver lts-3"
-  #  compiler: ": #stack 7.10.2"
-  #  addons: {apt: {packages: [libgmp-dev]}}
-
-  #- env: BUILD=stack ARGS="--resolver lts-6"
-  #  compiler: ": #stack 7.10.3"
-  #  addons: {apt: {packages: [libgmp-dev]}}
-
-  #- env: BUILD=stack ARGS="--resolver lts-7"
-  #  compiler: ": #stack 8.0.1"
-  #  addons: {apt: {packages: [libgmp-dev]}}
-
-  #- env: BUILD=stack ARGS="--resolver lts-9"
-  #  compiler: ": #stack 8.0.2"
-  #  addons: {apt: {packages: [libgmp-dev]}}
-
-  - env: BUILD=stack ARGS="--resolver lts-11"
-    compiler: ": #stack 8.2.2"
-    addons: {apt: {packages: [libgmp-dev]}}
-
-  # Nightly builds are allowed to fail
-  - env: BUILD=stack ARGS="--resolver nightly"
-    compiler: ": #stack nightly"
-    addons: {apt: {packages: [libgmp-dev]}}
-
-  # Build on macOS in addition to Linux
-  - env: BUILD=stack ARGS=""
-    compiler: ": #stack default osx"
-    os: osx
-
-  # Travis includes an macOS which is incompatible with GHC 7.8.4
-  #- env: BUILD=stack ARGS="--resolver lts-2"
-  #  compiler: ": #stack 7.8.4 osx"
-  #  os: osx
-
-  #- env: BUILD=stack ARGS="--resolver lts-3"
-  #  compiler: ": #stack 7.10.2 osx"
-  #  os: osx
-
-  #- env: BUILD=stack ARGS="--resolver lts-6"
-  #  compiler: ": #stack 7.10.3 osx"
-  #  os: osx
-
-  #- env: BUILD=stack ARGS="--resolver lts-7"
-  #  compiler: ": #stack 8.0.1 osx"
-  #  os: osx
-
-  #- env: BUILD=stack ARGS="--resolver lts-9"
-  #  compiler: ": #stack 8.0.2 osx"
-  #  os: osx
-
-  - env: BUILD=stack ARGS="--resolver lts-11"
-    compiler: ": #stack 8.2.2 osx"
-    os: osx
-
-  - env: BUILD=stack ARGS="--resolver nightly"
-    compiler: ": #stack nightly osx"
-    os: osx
-
+  - env: GHCVER=8.10.13 STACK_YAML=stack.yaml
+    addons:
+      apt:
+        sources:
+        - hvr-ghc
+        packages:
+        - ghc-8.10.13
   allow_failures:
-  - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
-  - env: BUILD=stack ARGS="--resolver nightly"
+    - env: GHCVER=head STACK_YAML=stack-head.yaml
+
 
 before_install:
-# Using compiler above sets CC to an invalid value, so unset it
-- unset CC
-
-# We want to always allow newer versions of packages when building on GHC HEAD
-- CABALARGS=""
-- if [ "x$GHCVER" = "xhead" ]; then CABALARGS=--allow-newer; fi
-
-# Download and unpack the stack executable
-- export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:/opt/alex/$ALEXVER/bin:/opt/happy/$HAPPYVER/bin:$HOME/.cabal/bin:$PATH
 - mkdir -p ~/.local/bin
-- |
-  if [ `uname` = "Darwin" ]
-  then
-    travis_retry curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
-  else
-    travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
-  fi
+- export PATH=$HOME/.local/bin:$PATH
+- travis_retry curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+- stack config set system-ghc --global true
+- export PATH=/opt/ghc/$GHCVER/bin:$PATH
 
-  # Use the more reliable S3 mirror of Hackage
-  mkdir -p $HOME/.cabal
-  echo 'remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/' > $HOME/.cabal/config
-  echo 'remote-repo-cache: $HOME/.cabal/packages' >> $HOME/.cabal/config
-
-  if [ "$CABALVER" != "1.16" ]
-  then
-    echo 'jobs: $ncpus' >> $HOME/.cabal/config
-  fi
-
-install:
-- echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
-- if [ -f configure.ac ]; then autoreconf -i; fi
-- |
-  set -ex
-  case "$BUILD" in
-    stack)
-      # Add in extra-deps for older snapshots, as necessary
-      stack --no-terminal --install-ghc $ARGS test --bench --dry-run || ( \
-        stack --no-terminal $ARGS build cabal-install && \
-        stack --no-terminal $ARGS solver --update-config)
-
-      # Build the dependencies
-      stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
-      ;;
-    cabal)
-      cabal --version
-      travis_retry cabal update
-
-      # Get the list of packages from the stack.yaml file. Note that
-      # this will also implicitly run hpack as necessary to generate
-      # the .cabal files needed by cabal-install.
-      PACKAGES=$(stack --install-ghc query locals | grep '^ *path' | sed 's@^ *path:@@')
-
-      cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
-      ;;
-  esac
-  set +ex
+addons:
+  apt:
+    sources:
+      - hvr-ghc
+    packages:
+      - ghc-8.10.13
 
 script:
-- |
-  set -ex
-  case "$BUILD" in
-    stack)
-      stack --no-terminal $ARGS test --bench --no-run-benchmarks --haddock --no-haddock-deps
-      ;;
-    cabal)
-      cabal install --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
-
-      ORIGDIR=$(pwd)
-      for dir in $PACKAGES
-      do
-        cd $dir
-        cabal check || [ "$CABALVER" == "1.16" ]
-        cabal sdist
-        PKGVER=$(cabal info . | awk '{print $2;exit}')
-        SRC_TGZ=$PKGVER.tar.gz
-        cd dist
-        tar zxfv "$SRC_TGZ"
-        cd "$PKGVER"
-        cabal configure --enable-tests --ghc-options -O0
-        cabal build
-        cabal test
-        cd $ORIGDIR
-      done
-      ;;
-  esac
-  set +ex
+  - stack --no-terminal --skip-ghc-check test
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,55 +1,40 @@
-# This is the complex Travis configuration, which is intended for use
-# on open source libraries which need compatibility across multiple GHC
-# versions, must work with cabal-install, and should be
-# cross-platform. For more information and other options, see:
+# This is the simple Travis configuration, which is intended for use
+# on applications which do not require cross-platform and
+# multiple-GHC-version support. For more information and other
+# options, see:
 #
 # https://docs.haskellstack.org/en/stable/travis_ci/
 #
+# Copy these contents into the root directory of your Github project in a file
+# named .travis.yml
 
-# Use new container infrastructure to enable caching
-sudo: false
+# Choose a build environment
+dist: xenial
+
+# Do not choose a language; we provide our own build tools.
+language: generic
 
 # Caching so the next build will be fast too.
 cache:
   directories:
-  - $HOME/.ghc
-  - $HOME/.cabal
   - $HOME/.stack
 
-  
-# The different configurations we want to test. We have BUILD=cabal
-# which uses cabal-install, and BUILD=stack which uses Stack. More
-# documentation on each of those below.
-#
-# We set the compiler values here to tell Travis to use a different
-# cache file per set of arguments.
-
-matrix:
-  include:
-  - env: GHCVER=8.10.13 STACK_YAML=stack.yaml
-    addons:
-      apt:
-        sources:
-        - hvr-ghc
-        packages:
-        - ghc-8.10.13
-  allow_failures:
-    - env: GHCVER=head STACK_YAML=stack-head.yaml
-
-
-before_install:
-- travis_retry curl -sSL https://get.haskellstack.org/ | sh
-- stack build
-- stack upgrade
-- export PATH=$HOME/.local/bin:$PATH
-
+# Ensure necessary system libraries are present
 addons:
   apt:
-    sources:
-      - hvr-ghc
     packages:
-      - ghc-8.10.13
+      - libgmp-dev
+
+before_install:
+# Download and unpack the stack executable
+- mkdir -p ~/.local/bin
+- export PATH=$HOME/.local/bin:$PATH
+- travis_retry curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+
+install:
+# Build dependencies
+- stack --no-terminal --install-ghc test --only-dependencies
 
 script:
-  - stack --no-terminal --skip-ghc-check test
-  
+# Build the package, its tests, and its docs and run the tests
+- stack --no-terminal test --haddock --no-haddock-deps

--- a/hs-conllu.cabal
+++ b/hs-conllu.cabal
@@ -1,5 +1,5 @@
 name:                hs-conllu
-version:             0.1.4
+version:             0.1.5
 synopsis:            Conllu validating parser and utils.
 description:         utilities to parse, print, diff, and analyse data in CoNLL-U format.
 extra-doc-files:      README
@@ -34,10 +34,10 @@ library
 --  other-modules: Conllu.Utils
   -- other-extensions:
   build-depends:       base >=4.9 && <5,
-                       containers >0.5.8 && <0.6,
+                       containers >0.5.8 && <0.7,
                        directory ==1.3.*,
                        filepath ==1.4.*,
-                       megaparsec ==6.*,
+                       megaparsec ==9.*,
                        void <1
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -47,10 +47,10 @@ executable hs-conllu
   main-is:            Main.hs
   default-language:   Haskell2010
   build-depends:      base >= 4.9 && <5,
-                      containers >0.5.8 && <0.6,
+                      containers >0.5.8 && <0.7,
                       directory ==1.3.*,
                       filepath ==1.4.*,
-                      megaparsec ==6.*
+                      megaparsec ==9.*
   other-modules:      Conllu.Type,
                       Conllu.UposTagset,
                       Conllu.DeprelTagset,

--- a/src/Conllu/Parse.hs
+++ b/src/Conllu/Parse.hs
@@ -214,7 +214,7 @@ deprel :: Parser DEPREL
 deprel = maybeEmpty deprel'
 
 dep :: Parser D.EP
-dep = fmap mkDEP $ TM.choice $ fmap (string' . show) [D.ACL .. D.XCOMP]
+dep = fmap mkDEP $ TM.choice $ fmap (string' . show) [D.REF .. D.XCOMP]
 
 deprel' :: Parser (D.EP, Maybe String)
 -- | parse a non-empty DEPREL field.

--- a/src/Conllu/Parse.hs
+++ b/src/Conllu/Parse.hs
@@ -60,19 +60,15 @@ import           Data.Either
 import           Data.Maybe
 import           Data.Void (Void)
 
-import Text.Megaparsec
-       (ParseError, Parsec, (<?>), (<|>), between, choice, eitherP, endBy1, eof,
-        lookAhead, many, option, optional, parse, parseErrorPretty, sepBy,
-        sepBy1, skipManyTill, some, takeWhile1P, takeWhileP, try,
-        withRecovery)
+import qualified Text.Megaparsec as TM 
 import           Text.Megaparsec.Char
 import qualified Text.Megaparsec.Char.Lexer as L
 
 -- | Parser type synonym
-type Parser = Parsec Void String
+type Parser = TM.Parsec Void String
 
 -- | Parser raw output
-type RawData t e = [Either (ParseError t e) Sent]
+type RawData t e = [Either (TM.ParseError t e) Sent]
 
 -- | DEPREL field type synonym
 type DEPREL = Maybe (D.EP, Maybe String)
@@ -80,42 +76,40 @@ type DEPREL = Maybe (D.EP, Maybe String)
 
 ---
 -- conllu parsers
-rawSents :: Parser (RawData Char Void)
+rawSents :: Parser (RawData String Void)
 -- | parse CoNLL-U sentences with recovery.
 rawSents = rawSentsC sentence
 
-rawSentsC :: Parser Sent -> Parser (RawData Char Void)
+rawSentsC :: Parser Sent -> Parser (RawData String Void)
 -- | parse CoNLL-U sentences with recovery, using a custom parser.
-rawSentsC sent = between ws eof (e `endBy1` lineFeed)
+rawSentsC sent = TM.between ws TM.eof (TM.endBy1 e lineFeed)
   where
-    e = withRecovery recover (Right <$> sent)
+    e = TM.withRecovery recover (Right <$> sent)
     recover err =
       Left err <$
-      skipManyTill anyChar
+      TM.skipManyTill TM.anySingle
       -- if parser consumes the first newline but can't parse the
       -- second, it breaks; it can't consume the second one, because
       -- that one has to be consumed by the endBy1
-      (try $ lineFeed *> lookAhead lineFeed)
+      (TM.try $ lineFeed *> TM.lookAhead lineFeed)
 
 lineFeed :: Parser ()
--- | parse a blank line.
-lineFeed = lexeme . void $ newline -- spaces shouldn't exist, but no
-                                    -- problem being lax here
+-- | parse a blank line. Spaces shouldn't exist, but no problem being lax here
+lineFeed = lexeme . void $ newline 
 
 sentence :: Parser Sent
 -- | the default sentence parser.
 sentence = sentenceC comment word
 
-sentenceC :: Parser Comment -> Parser (CW AW)
-  -> Parser Sent
+sentenceC :: Parser Comment -> Parser (CW AW) -> Parser Sent
 -- | the customizable sentence parser.
-sentenceC c t = liftM2 Sent (many c) (some t)
+sentenceC c t = liftM2 Sent (TM.many c) (TM.some t)
 
 comment :: Parser Comment
 -- | parse a comment.
 comment =
-  (symbol "#" <?> "comment starter") *> commentPair <*
-  lineFeed <?> "comment content"
+  (symbol "#" TM.<?> "comment starter") *> commentPair <*
+  lineFeed TM.<?> "comment content"
 
 word :: Parser (CW AW)
 -- | the default word parser.
@@ -135,19 +129,19 @@ wordC ::
   -> Parser (CW AW)
 -- | the customizable token parser.
 wordC ixp fop lp upp xpp fsp drp dsp mp = do
-  i <- ixp <* tab
-  mf <- fop <* tab
-  ml <- lp <* tab
+  i   <- ixp <* tab
+  mf  <- fop <* tab
+  ml  <- lp  <* tab
   mup <- upp <* tab
   mxp <- xpp <* tab
   mfs <- fsp <* tab
   mdh <- dhp <* tab
   mdr <- drp <* tab
-  ds <- dsp <* tab
-  mm <- mp <* lineFeed
+  ds  <- dsp <* tab
+  mm  <- mp  <* lineFeed
   return $ mkAW i mf ml mup mxp mfs (rel mdh mdr) ds mm
   where
-    dhp = maybeEmpty ixp <?> "HEAD"
+    dhp = maybeEmpty ixp TM.<?> "HEAD"
     rel :: Maybe ID -> DEPREL -> Maybe Rel
     rel mdh mdr = do
       dh <- mdh
@@ -156,14 +150,14 @@ wordC ixp fop lp upp xpp fsp drp dsp mp = do
 
 emptyField :: Parser (Maybe a)
 -- | parse an empty field.
-emptyField = symbol "_" *> return Nothing <?> "empty field (_)"
+emptyField = symbol "_" *> return Nothing TM.<?> "empty field (_)"
 
 idW :: Parser ID
 -- | parse the ID field, which might be an integer, a range, or a
 -- decimal.
 idW = do
   ix <- index
-  mix <- optional metaIndex <?> "meta token ID"
+  mix <- TM.optional metaIndex TM.<?> "meta token ID"
   return $
     case mix of
       Nothing             -> SID ix
@@ -172,10 +166,10 @@ idW = do
   where
     index :: Parser Index
     index = do
-      ix <- some digitChar <?> "ID"
+      ix <- TM.some digitChar TM.<?> "ID"
       return (read ix :: Int)
     indexSep :: Parser (Either IxSep IxSep)
-    indexSep = eitherP (char '-') (char '.') <?> "meta separator"
+    indexSep = TM.eitherP (char '-') (char '.') TM.<?> "meta separator"
     metaIndex :: Parser (Either IxSep IxSep, Index)
     metaIndex = do
       sep <- indexSep
@@ -184,85 +178,85 @@ idW = do
 
 form :: Parser FORM
 -- | parse the FORM field.
-form = orEmpty stringWSpaces <?> "FORM"
+form = orEmpty stringWSpaces TM.<?> "FORM"
 
 lemma :: Parser LEMMA
 -- | parse the LEMMA field.
-lemma = orEmpty stringWSpaces <?> "LEMMA"
+lemma = orEmpty stringWSpaces TM.<?> "LEMMA"
 
 upos :: Parser UPOS
 -- | parse the UPOS field.
 upos = maybeEmpty upos'
   where
     upos' :: Parser U.POS
-    upos' = fmap mkUPOS $ choice $ fmap (string' . show) [U.ADJ .. U.X]
+    upos' = fmap mkUPOS $ TM.choice $ fmap (string' . show) [U.ADJ .. U.X]
 
 xpos :: Parser XPOS
 -- | parse the XPOS field.
-xpos = maybeEmpty stringWOSpaces <?> "XPOS"
+xpos = maybeEmpty stringWOSpaces TM.<?> "XPOS"
 
 feats :: Parser FEATS
 -- | parse the FEATS field.
-feats = listP (feat `sepBy` symbol "|" <?> "FEATS")
+feats = listP (feat `TM.sepBy` symbol "|" TM.<?> "FEATS")
   where
     feat = do
-      k  <- lexeme (some alphaNumChar <?> "feature key")
+      k  <- lexeme (TM.some alphaNumChar TM.<?> "feature key")
       ft <-
-        optional $
-        between (symbol "[") (symbol "]") (some alphaNumChar)
+        TM.optional $
+        TM.between (symbol "[") (symbol "]") (TM.some alphaNumChar)
       _  <- symbol "="
-      vs <- fvalue `sepBy1` symbol ","
+      vs <- fvalue `TM.sepBy1` symbol ","
       return $ Feat k vs ft
-    fvalue = lexeme (some alphaNumChar <?> "feature value")
+    fvalue = lexeme (TM.some alphaNumChar TM.<?> "feature value")
 
 deprel :: Parser DEPREL
 -- | parse the DEPREL field.
 deprel = maybeEmpty deprel'
 
 dep :: Parser D.EP
-dep = fmap mkDEP $ choice $ fmap (string' . show) [D.ACL .. D.XCOMP]
+dep = fmap mkDEP $ TM.choice $ fmap (string' . show) [D.ACL .. D.XCOMP]
 
 deprel' :: Parser (D.EP, Maybe String)
 -- | parse a non-empty DEPREL field.
 deprel' = liftM2 (,) dep subdeprel
   where
     subdeprel :: Parser (Maybe String)
-    subdeprel = optional (symbol ":" *> letters <?> "DEPREL subtype")
+    subdeprel = TM.optional (symbol ":" *> letters TM.<?> "DEPREL subtype")
 
 deps :: Parser DEPS
 -- | parse the DEPS field.
-deps = listP (eDep `sepBy` symbol "|" <?> "DEPS")
+deps = listP (eDep `TM.sepBy` symbol "|" TM.<?> "DEPS")
   where
     eDep = do
-      h <- idW <?> "enhanced dependency HEAD"
+      h <- idW TM.<?> "enhanced dependency HEAD"
       _ <- sep
-      d <- dep <?> "enhanced dependency DEPREL"
+      d <- dep TM.<?> "enhanced dependency DEPREL"
       restI <-
-        optional
+        TM.optional
           (sep *>
-           stringNot "\t| :" `sepBy` sep <?>
+           stringNot "\t| :" `TM.sepBy` sep TM.<?>
            "enhanced dependency information")
       return $ Rel h d Nothing restI
     sep = symbol ":"
 
 misc :: Parser MISC
 -- | parse the MISC field.
-misc = orEmpty stringWSpaces <?> "MISC"
+misc = orEmpty stringWSpaces TM.<?> "MISC"
 
 ---
 -- utility parsers
 commentPair :: Parser Comment
 -- | parse a comment pair.
 commentPair =
-  keyValue "=" (stringNot "=\n\t") (option "" stringWSpaces)
+  keyValue "=" (stringNot "=\n\t") (TM.option "" stringWSpaces)
 
 listPair :: String -> Parser a -> Parser b -> Parser [(a, b)]
 -- | parse a list of pairs.
-listPair sep p q = keyValue sep p q `sepBy1` symbol "|"
+listPair sep p q = keyValue sep p q `TM.sepBy1` symbol "|"
 
 stringNot :: String -> Parser String
 -- | parse any chars except the ones provided.
-stringNot s = lexeme $ takeWhile1P Nothing (`notElem` s)
+stringNot s = lexeme $ TM.takeWhile1P Nothing (`notElem` s)
 
 stringWOSpaces :: Parser String
 -- | parse a string until a space, a tab, or a newline.
@@ -274,7 +268,7 @@ stringWSpaces = stringNot "\t\n"
 
 letters :: Parser String
 -- | parse a string of letters.
-letters = lexeme $ some letterChar
+letters = lexeme $ TM.some letterChar
 
 ---
 -- parser combinators
@@ -282,7 +276,7 @@ keyValue :: String -> Parser a -> Parser b -> Parser (a, b)
 -- | parse a (key, value) pair.
 keyValue sep p q = do
   key   <- p
-  _     <- optional $ symbol sep
+  _     <- TM.optional $ symbol sep
   value <- q
   return (key, value)
 
@@ -302,7 +296,7 @@ keyValue sep p q = do
 maybeEmpty :: Parser a -> Parser (Maybe a)
 -- | a parser combinator for parsers that won't parse "_" (e.g., as
 -- 'lemma' would).
-maybeEmpty p = emptyField <|> fmap Just p
+maybeEmpty p = emptyField TM.<|> fmap Just p
 
 orEmpty :: Parser String -> Parser (Maybe String)
 -- | a parser combinator for parsers that may parse "_".
@@ -328,7 +322,7 @@ lexeme :: Parser a -> Parser a
 lexeme = L.lexeme ws
 
 ws :: Parser ()
-ws = void $ takeWhileP (Just "space") (== ' ')
+ws = void $ TM.takeWhileP (Just "space") (== ' ')
 
 ---
 -- customizable parser
@@ -369,7 +363,7 @@ parserC :: ParserC -> Parser Sent
 -- @
 parserC p =
   let i  = _idP p
-      f = _formP p
+      f  = _formP p
       l  = _lemmaP p
       up = _upostagP p
       xp = _xpostagP p
@@ -392,15 +386,16 @@ parseConlluWith
   -> Either String Doc
 -- | parse a CoNLL-U document using a customized parser.
 parseConlluWith p fp s =
-  case parse doc fp s of
-    Left err -> Left $ parseErrorPretty err
-    Right d ->
+  case TM.parse doc fp s of
+    Left err -> Left $ TM.errorBundlePretty err
+    Right d  ->
       let (ls, rs) = partitionEithers d
       in if null ls
            then Right rs
-           else Left $ concatMap parseErrorPretty ls
+           else Left $ concatMap TM.parseErrorPretty ls
   where
     doc = rawSentsC p
+
 
 parseConllu :: FilePath -> String -> Either String Doc
 -- | parse a CoNLL-U document using the default parser.

--- a/src/Conllu/Type.hs
+++ b/src/Conllu/Type.hs
@@ -83,10 +83,12 @@ data ID -- | Word ID field.
         Index -- ^ empty node ID is a decimal
   deriving (Eq, Show)
 
+
 instance Ord ID where
   compare = idOrd
     where
       idOrd :: ID -> ID -> Ordering
+      idOrd (SID x) (SID y) = compare x y
       idOrd id1 id2 =
         let c = comparing fstIx id1 id2
         in case c of
@@ -142,7 +144,7 @@ _dep w = Just . _deprel =<< _rel w
 
 depIs :: D.EP -> CW SW -> Bool
 -- | check if DEP is the one provided.
-depIs d = maybe False (d ==) . _dep
+depIs d = (Just d ==) . _dep
 
 ---
 -- ** constructor functions

--- a/src/Conllu/Type.hs
+++ b/src/Conllu/Type.hs
@@ -142,7 +142,7 @@ _dep w = Just . _deprel =<< _rel w
 
 depIs :: D.EP -> CW SW -> Bool
 -- | check if DEP is the one provided.
-depIs d = maybe False (\d' -> d == d') . _dep
+depIs d = maybe False (d ==) . _dep
 
 ---
 -- ** constructor functions

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-10.3
+resolver: lts-17.2
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION

The lib now builds with lts-17.2. It means dependencies are 

```
 
  build-depends:       base >=4.9 && <5,
                       containers >0.5.8 && <0.7,
                       directory ==1.3.*,
                       filepath ==1.4.*,
                       megaparsec ==9.*,
                       void <1
``` 

I tried to follow the code style as close as possible. But I show to import Text.Megaparsec with `qualified` option adopting the prefix TM.  

I didn't understand yet what the comments starting with `-- |` means. Maybe a kind of docstring? For instance:

```haskell
---
-- conllu parsers
rawSents :: Parser (RawData String Void)
-- | parse CoNLL-U sentences with recovery.
rawSents = rawSentsC sentence
```

The `---` is a section? Why the comment need to be between the type signature and the implementation? 


